### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/tiger-demo/src/main/java/com/xxx/tiger/demo/support/impl/DispatchTaskServiceImpl.java
+++ b/tiger-demo/src/main/java/com/xxx/tiger/demo/support/impl/DispatchTaskServiceImpl.java
@@ -86,11 +86,11 @@ public class DispatchTaskServiceImpl implements DispatchMultiService{
 	@Override
 	public List<DispatchTaskEntity> findDispatchTasksWithLimit(String handler,
 			List<Integer> nodeList, int limit) {
-		if(StringUtils.isBlank(handler) || nodeList == null || nodeList.size() == 0){
+		if(StringUtils.isBlank(handler) || nodeList == null || nodeList.isEmpty()){
 			return null;
 		}
 		List<TigerTaskDo> doList = dispatchTaskDao.findDispatchTasksWithLimit(handler, nodeList, limit);
-		if(doList == null || doList.size() == 0){
+		if(doList == null || doList.isEmpty()){
 			return null;
 		}
 		List<DispatchTaskEntity> taskList = new ArrayList<DispatchTaskEntity>();
@@ -106,11 +106,11 @@ public class DispatchTaskServiceImpl implements DispatchMultiService{
 	public List<DispatchTaskEntity> findDispatchTasksWithLimitByBackFetch(
 			String handler, List<Integer> nodeList, int limit, long taskId) {
 		if(StringUtils.isBlank(handler) || nodeList == null 
-				|| nodeList.size() == 0 || taskId < 1){
+				|| nodeList.isEmpty() || taskId < 1){
 			return null;
 		}
 		List<TigerTaskDo> doList = dispatchTaskDao.findDispatchTasksWithLimitByBackFetch(handler, nodeList, limit, taskId);
-		if(doList == null || doList.size() == 0){
+		if(doList == null || doList.isEmpty()){
 			return null;
 		}
 		List<DispatchTaskEntity> taskList = new ArrayList<DispatchTaskEntity>();

--- a/tiger/src/main/java/com/dianping/tiger/ScheduleManager.java
+++ b/tiger/src/main/java/com/dianping/tiger/ScheduleManager.java
@@ -51,7 +51,7 @@ public class ScheduleManager {
 						}
 						List<String> serverList = zkClient.getChildren()
 								.forPath(path);
-						if (serverList == null || serverList.size() == 0) {
+						if (serverList == null || serverList.isEmpty()) {
 							logger.warn("scheduleServer init ok, but serverList is empty.path="+path);
 							continue;
 						}
@@ -109,7 +109,7 @@ public class ScheduleManager {
 								List<String> handlers = new ArrayList<String>();
 								Set<String> handlerSet = ScheduleServer
 										.getInstance().getHandlers();
-								if (handlerSet.size() == 0) {
+								if (handlerSet.isEmpty()) {
 									logger.warn("handler config is empty, ignore,"
 											+ serverList);
 									continue;
@@ -120,7 +120,7 @@ public class ScheduleManager {
 												currentRegisterVersion);
 								// 自我分配节点
 								List<Integer> newNodeList = getNodeList(serverList);
-								if (newNodeList.size() == 0) {
+								if (newNodeList.isEmpty()) {
 									logger.warn("registerversion changed, new nodeList is empty,hostName="
 											+ ScheduleServer.getInstance()
 													.getServerName()

--- a/tiger/src/main/java/com/dianping/tiger/event/EventFetcher.java
+++ b/tiger/src/main/java/com/dianping/tiger/event/EventFetcher.java
@@ -43,7 +43,7 @@ public class EventFetcher {
 		if (ScheduleServer.getInstance().getTaskStrategy() == ScheduleConstants.TaskFetchStrategy.Multi
 				.getValue()) {// 各个执行器捞取策略
 			if (StringUtils.isBlank(handlerName) || nodeList == null
-					|| nodeList.size() == 0) {
+					|| nodeList.isEmpty()) {
 				throw new IllegalArgumentException(
 						"handlerName or nodeList is empty.");
 			}
@@ -56,7 +56,7 @@ public class EventFetcher {
 			return tasks;
 		}
 		//单个执行器统一捞取策略
-		if (nodeList == null || nodeList.size() == 0) {
+		if (nodeList == null || nodeList.isEmpty()) {
 			throw new IllegalArgumentException("nodeList is empty.");
 		}
 		DispatchSingleService dispatchSingleService = (DispatchSingleService) dispatchTaskService;
@@ -81,7 +81,7 @@ public class EventFetcher {
 		if (ScheduleServer.getInstance().getTaskStrategy() == ScheduleConstants.TaskFetchStrategy.Multi
 				.getValue()) {// 各个执行器捞取策略
 			if (StringUtils.isBlank(handlerName) || nodeList == null
-					|| nodeList.size() == 0 || taskId < 1) {
+					|| nodeList.isEmpty() || taskId < 1) {
 				throw new IllegalArgumentException(
 						"backFetch task,handlerName or nodeList is empty,or taskId smaller than 1");
 			}
@@ -95,7 +95,7 @@ public class EventFetcher {
 			return tasks;
 		}
 		//单个执行器统一捞取策略
-		if (nodeList == null || nodeList.size() == 0 || taskId < 1) {
+		if (nodeList == null || nodeList.isEmpty() || taskId < 1) {
 			throw new IllegalArgumentException(
 					"backFetch task, nodeList is empty,or taskId smaller than 1");
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.